### PR TITLE
release remaining sensor detectors

### DIFF
--- a/sensey/src/main/java/com/github/nisrulz/sensey/Sensey.java
+++ b/sensey/src/main/java/com/github/nisrulz/sensey/Sensey.java
@@ -428,6 +428,10 @@ public class Sensey {
      * Stop.
      */
     public void stop() {
+        for (SensorDetector sensor : defaultSensorsMap.values()) {
+            stopSensorDetection(sensor);
+        }
+        defaultSensorsMap.clear();
         this.sensorManager = null;
     }
 


### PR DESCRIPTION
<!-- * Please fill out the blanks below describing your pull request * -->

**What does this implement/fix? Explain your changes**
This PR fixes possible leak that users may encounter if they don't stop their specific sensor detectors. For ex. in this scenario:
```
class ShakeActivity : AppCompatActivity(), ShakeDetector.ShakeListener {

    override fun onCreate(savedInstanceState: Bundle?) {
        super.onCreate(savedInstanceState)
        setContentView(R.layout.activity_shake)

        Sensey.getInstance().init(this)
        Sensey.getInstance().startShakeDetection(this)
    }

    override fun onShakeStopped() {
        tvStatus.text = "Shake: Stopped"
    }

    override fun onShakeDetected() {
        tvStatus.text = "Shake: Detected"
        // this will show "Shake" even if this ShakeActivity destroyed
        Toast.makeText(this, "Shake", Toast.LENGTH_SHORT).show()
    }

    override fun onDestroy() {
        Sensey.getInstance().stop()
        super.onDestroy()
    }
}
```
As you can see above, in `onDestroy()` of `ShakeActivity`,  I omitted `stopShakeDetection(this)` since I was expecting `Sensey.getInstance().stop() ` should stop all the registered sensor detectors (maybe, others are doing this too). If you leave `ShakeActivity` in the above example and shake, toast "Shake" still appear because Sensey is still holding a reference to it

**Does this close any currently open issues?**
I am not sure if this solves #26, as far as I understood it is similar to my case (the above example)

**Any relevant logs, error output, bugreport etc?**
I tested it locally, LeakCanary shows "ShakeActivity leaked 45Kb" on my device.